### PR TITLE
Allow olmo users to specify non-Olmo pytorch datasets in the config

### DIFF
--- a/configs/kempner_institute/7b_Olmo_tatm.yaml
+++ b/configs/kempner_institute/7b_Olmo_tatm.yaml
@@ -1,0 +1,168 @@
+run_name: OLMo-7B
+seed: 6198
+dry_run: false
+
+# Comment out the wandb section if you don't wish to use wandb for logging
+# Otherwise update it according to your account info and it's setup on the cluster
+#wandb:
+#  name: ${run_name}
+#  project: olmo-medium
+#  group: OLMo-7B
+
+model:
+  d_model: 4096
+  n_heads: 32
+  n_layers: 32
+  mlp_hidden_size: 16384 # default: 4 * d_model
+  weight_tying: false
+  alibi: false
+  rope: true
+  flash_attention: false
+  attention_dropout: 0.0
+  attention_layer_norm: true
+  multi_query_attention: false
+  include_bias: false
+  block_type: sequential
+  layer_norm_type: default
+  layer_norm_with_affine: true
+  bias_for_layer_norm: false
+  attention_layer_norm_with_affine: true
+  activation_type: gelu
+  residual_dropout: 0.0
+  embedding_dropout: 0.0
+  max_sequence_length: 2048
+  vocab_size: 32100           # depends on the tokenizer
+  embedding_size: 32128 
+  eos_token_id: 1
+  pad_token_id: 0
+  init_device: cuda
+  init_fn: mitchell
+
+compile: # causes instability on AMD GPUs
+  fullgraph: false
+
+activation_checkpointing: whole_layer
+
+optimizer:
+  name: adamw
+  learning_rate: 3.0e-4
+  weight_decay: 0.1
+  betas:
+  - 0.9
+  - 0.95
+  metrics_log_interval: 100
+
+scheduler:
+  name: cosine_with_warmup
+  t_warmup: 1000
+  alpha_f: 0.1
+  grad_clip_warmup_steps: 1000
+  grad_clip_warmup_factor: 10.0
+
+tokenizer:
+  identifier: t5-base
+  truncate_direction: right
+
+save_folder: ${oc.env:CHECKPOINTS_PATH}
+remote_save_folder: null
+save_overwrite: false
+# Sharded checkpoints (best for restarts)
+save_interval: 100
+save_num_checkpoints_to_keep: -1
+# Unsharded checkpoints (for final storage)
+save_interval_unsharded: null
+save_num_unsharded_checkpoints_to_keep: -1
+
+load_path: null
+
+max_duration: 515  # 135M tokens (global_train_batch_size * max_sequence_length * max_duration)
+global_train_batch_size: 128 # 4 GPUs * 32
+device_train_microbatch_size: 32
+time_limit: null
+
+precision: amp_bf16
+
+ddp:
+  grad_sync_mode: batch
+
+distributed_strategy: fsdp
+
+fsdp:
+  wrapping_strategy: by_block
+  precision: mixed
+  sharding_strategy: FULL_SHARD
+
+max_grad_norm: 1.0
+max_grad_norm_ratio: null
+
+speed_monitor:
+  window_size: 20
+
+eval_interval: ${save_interval}
+eval_subset_num_batches: 5 # limit how many batches to evaluate on (set to -1 for all batches)
+device_eval_batch_size: ${device_train_microbatch_size}
+
+evaluators:
+  - label: all-small-ppl-validation
+    data:
+      datasets:
+        c4_val: ${path.glob:/n/kempner_shared/Everyone/data/dolma/preprocessed/t5-base/c4_val/*.npy}
+      drop_last: true
+
+  ##########################
+  # Downstream evaluations #
+  ##########################
+  - label: piqa
+    type: downstream
+
+  - label: hellaswag
+    type: downstream
+
+  - label: winogrande
+    type: downstream
+
+  - label: openbook_qa
+    type: downstream
+
+  # - label: boolq  # requires implemention of the pmi_dc matrix
+    # type: downstream
+
+  - label: sciq
+    type: downstream
+
+  - label: arc_easy
+    type: downstream
+
+  # - label: arc_challenge  # requires implemention of the pmi_dc matrix
+  #   type: downstream
+
+  - label: copa
+    type: downstream
+
+  - label: rte
+    type: downstream
+
+  - label: commitment_bank
+    type: downstream
+
+  - label: mrpc
+    type: downstream
+
+  - label: sst2
+    type: downstream
+
+data:
+  pad_direction: right
+  num_workers: 2
+  drop_last: true
+  pin_memory: true
+  prefetch_factor: 1
+  persistent_workers: true
+  timeout: 0
+  custom_dataset:
+    name: "tatm.data.get_dataset"
+    args:
+      metadata: "Red Pajama v1-tokenized_t5-base_arxiv"
+      context_length: 2048
+    collate_config:
+      input_id_field: "token_ids"

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -621,6 +621,9 @@ class DataConfig(BaseConfig):
     timeout: int = 0
     seed: Optional[int] = None
     instance_filter: Optional[InstanceFilterConfig] = None
+    custom_dataset_class: Optional[str] = None
+    custom_dataset_module: Optional[str] = None
+    custom_dataset_args: Optional[Dict[str, Any]] = None
 
     @property
     def effective_memmap_dtype(self):

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -621,9 +621,7 @@ class DataConfig(BaseConfig):
     timeout: int = 0
     seed: Optional[int] = None
     instance_filter: Optional[InstanceFilterConfig] = None
-    custom_dataset_class: Optional[str] = None
-    custom_dataset_module: Optional[str] = None
-    custom_dataset_args: Optional[Dict[str, Any]] = None
+    custom_dataset: Optional[CustomDatasetConfig] = None
 
     @property
     def effective_memmap_dtype(self):
@@ -634,6 +632,27 @@ class DataConfig(BaseConfig):
         except (AttributeError, TypeError) as e:
             raise TypeError(f"Value {self.memmap_dtype} is not a valid numpy type") from e
         return dtype
+
+@dataclass
+class CustomDatasetCollatorConfig(BaseConfig):
+    input_id_field: str = "input_ids" #: The field in the dataset items that contains the input token IDs.
+    attention_mask_field: Optional[str] = None #: The field in the dataset items that contains the attention mask.
+    attention_bias_field: Optional[str] = None #: The field in the dataset items that contains the attention bias.
+    label_mask_field: Optional[str] = None #: The field in the dataset items that contains the label mask.
+    index_field: Optional[str] = None #: The field in the dataset items that contains the index of the item.
+    instance_mask_field: Optional[str] = None #: The field in the dataset items that contains the instance mask.
+    doc_lens_field: Optional[str] = None #: The field in the dataset items that contains the document lengths.
+    metadata_field: Optional[str] = None #: The field in the dataset items that contains the metadata.
+
+
+@dataclass
+class CustomDatasetConfig(BaseConfig):
+    name: str #: The name of the custom dataset class or function that will be used to load the dataset.
+    module: Optional[str] = None #: The module where the custom dataset class is defined. If not set, the module will be inferred from the class name.
+    args: Optional[Dict[str, Any]] = None #: The arguments to pass to the custom dataset class or function
+    collate_fn: Optional[str] = None #: The name of the collate function to use for the custom dataset. Assumes the collate function is defined in the same module as the custom dataset class unless specified otherwise using the full object path.
+    token_field: Optional[str] = None #: The field in the dataset items that contains the tokenized text.
+    collate_config: Optional[CustomDatasetCollatorConfig] = field(default_factory=CustomDatasetCollatorConfig) #: The configuration for the collate function to use for the custom dataset.
 
 
 class EvaluatorType(StrEnum):

--- a/olmo/data/__init__.py
+++ b/olmo/data/__init__.py
@@ -136,38 +136,27 @@ def build_train_dataloader(
         dataset = build_memmap_dataset(
             train_config, train_config.data, include_instance_metadata=include_instance_metadata
         )
-        work_dir = Path(train_config.save_folder) / "train_data"
-        if get_global_rank() == 0:
-            if work_dir.is_dir() and not train_config.save_overwrite:
-                raise OLMoConfigurationError(
-                    "train data working directory already exists, use --save_overwrite to overwrite"
-                )
-            else:
-                work_dir.mkdir(exist_ok=True, parents=True)
-        dataset = IterableDataset(
-            dataset,  # type: ignore
-            train_config.global_train_batch_size,
-            seed=seed,
-            epoch=train_config.epoch or 0,
-            shuffle=True,
-            drop_last=train_config.data.drop_last,
-            world_size=world_size,
-            rank=rank,
-            fs_local_rank=fs_local_rank,
-            work_dir=work_dir,
-        )
+    work_dir = Path(train_config.save_folder) / "train_data"
+    if get_global_rank() == 0:
+        if work_dir.is_dir() and not train_config.save_overwrite:
+            raise OLMoConfigurationError(
+                "train data working directory already exists, use --save_overwrite to overwrite"
+            )
+        else:
+            work_dir.mkdir(exist_ok=True, parents=True)
+    dataset = IterableDataset(
+        dataset,  # type: ignore
+        train_config.global_train_batch_size,
+        seed=seed,
+        epoch=train_config.epoch or 0,
+        shuffle=True,
+        drop_last=train_config.data.drop_last,
+        world_size=world_size,
+        rank=rank,
+        fs_local_rank=fs_local_rank,
+        work_dir=work_dir,
+    )
     barrier()
-    if train_config.data.custom_dataset:
-        sampler = DistributedSampler(          
-            dataset,
-            drop_last=train_config.data.drop_last,
-            shuffle=True,
-            num_replicas=get_world_size(),
-            rank=get_global_rank(),
-            seed=seed,
-        )
-    else:
-        sampler = None
     out = DataLoader(
         dataset,
         batch_size=train_config.device_train_batch_size,
@@ -178,6 +167,5 @@ def build_train_dataloader(
         prefetch_factor=None if train_config.data.num_workers == 0 else train_config.data.prefetch_factor,
         persistent_workers=False if train_config.data.num_workers == 0 else train_config.data.persistent_workers,
         timeout=train_config.data.timeout,
-        sampler=sampler,
     )
     return out

--- a/olmo/data/__init__.py
+++ b/olmo/data/__init__.py
@@ -1,19 +1,22 @@
 import importlib
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
-from torch.utils.data import DataLoader, DistributedSampler, Dataset
+from torch.utils.data import DataLoader, DistributedSampler
 
 from ..aliases import PathOrStr
 from ..config import DataConfig, TrainConfig
 from ..exceptions import OLMoConfigurationError
 from ..torch_util import barrier, get_global_rank, get_world_size
-from .collator import DataCollator
+from .collator import DataCollator, CustomDatasetDataCollator
+from .custom_datasets import build_custom_dataset, extract_module_and_class
 from .iterable_dataset import IterableDataset
 from .memmap_dataset import MemMapDataset
 
 __all__ = ["MemMapDataset", "DataCollator", "IterableDataset", "build_eval_dataloader", "build_train_dataloader"]
 
+LOGGER = logging.getLogger(__name__)
 
 def build_memmap_dataset(
     train_config: TrainConfig, data_config: DataConfig, include_instance_metadata: bool = True
@@ -49,27 +52,32 @@ def build_memmap_dataset(
     )
 
 
-def build_custom_dataset(train_config: TrainConfig) -> Dataset:
-    if not train_config.data.custom_dataset_class:
-        raise OLMoConfigurationError("custom_dataset_class is required when using a custom dataset")
-    dataset_class = train_config.data.custom_dataset_class
-    dataset_module = train_config.data.custom_dataset_module
-    if not dataset_module:
-        class_module = dataset_class.split(".") 
-        if len(class_module) < 2:
-            raise OLMoConfigurationError(
-                "when using custom_dataset_class, use the full module path of the class or specify custom_dataset_module"
-            )
-        dataset_module = ".".join(class_module[:-1])
-        dataset_class = class_module[-1]
-    module = importlib.import_module(dataset_module)
-    dataset_class = getattr(module, dataset_class)
-    return dataset_class(**train_config.data.custom_dataset_args)
+
 
 def build_collator(train_config: TrainConfig) -> DataCollator:
-    return DataCollator(
-        pad_direction=train_config.data.pad_direction, pad_token_id=train_config.model.pad_token_id
-    )
+    if train_config.data.custom_dataset:
+        if train_config.data.custom_dataset.collate_fn:
+            module, function = extract_module_and_class(train_config.data.custom_dataset.collate_fn)
+            if module is None:
+                if train_config.data.custom_dataset.module is None:
+                    module, _ = extract_module_and_class(train_config.data.custom_dataset.name)
+                else:
+                    module = train_config.data.custom_dataset.module
+            try:
+                collator = getattr(importlib.import_module(module), function)
+            except AttributeError:
+                raise OLMoConfigurationError(f"collate_fn {train_config.data.custom_dataset.collate_fn} not found in {module}. Please specify the full module path of the function.")
+            return collator
+            
+        return CustomDatasetDataCollator(
+            pad_direction=train_config.data.pad_direction,
+            pad_token_id=train_config.model.pad_token_id,
+            **train_config.data.custom_dataset.collate_config.asdict(),  # type: ignore
+        )
+    else:
+        return DataCollator(
+            pad_direction=train_config.data.pad_direction, pad_token_id=train_config.model.pad_token_id
+        )
 
 
 def build_eval_dataloader(
@@ -118,7 +126,7 @@ def build_train_dataloader(
     assert train_config.device_train_batch_size is not None
     seed = train_config.data.seed if train_config.data.seed is not None else train_config.seed
     collator = build_collator(train_config)
-    if train_config.data.custom_dataset_class:
+    if train_config.data.custom_dataset:
         if train_config.data.paths is not None or train_config.data.datasets is not None:
             raise OLMoConfigurationError(
                 "custom_dataset_class is mutually exclusive with DataConfig.paths and DataConfig.datasets"
@@ -149,6 +157,17 @@ def build_train_dataloader(
             work_dir=work_dir,
         )
     barrier()
+    if train_config.data.custom_dataset:
+        sampler = DistributedSampler(          
+            dataset,
+            drop_last=train_config.data.drop_last,
+            shuffle=True,
+            num_replicas=get_world_size(),
+            rank=get_global_rank(),
+            seed=seed,
+        )
+    else:
+        sampler = None
     out = DataLoader(
         dataset,
         batch_size=train_config.device_train_batch_size,
@@ -159,14 +178,6 @@ def build_train_dataloader(
         prefetch_factor=None if train_config.data.num_workers == 0 else train_config.data.prefetch_factor,
         persistent_workers=False if train_config.data.num_workers == 0 else train_config.data.persistent_workers,
         timeout=train_config.data.timeout,
+        sampler=sampler,
     )
-    if train_config.data.custom_dataset_class:
-        out.sampler = DistributedSampler(          
-            dataset,
-            drop_last=train_config.data.drop_last,
-            shuffle=True,
-            num_replicas=get_world_size(),
-            rank=get_global_rank(),
-            seed=seed,
-        )
     return out

--- a/olmo/data/custom_datasets.py
+++ b/olmo/data/custom_datasets.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 from typing import Optional, Tuple
 
 from torch.utils.data import Dataset
@@ -8,9 +9,13 @@ from ..exceptions import OLMoConfigurationError
 
 __all__ = ["build_custom_dataset"]
 
+LOGGER = logging.getLogger(__name__)
+
 def build_custom_dataset(train_config: TrainConfig) -> Dataset:
     if not train_config.data.custom_dataset.name:
         raise OLMoConfigurationError("custom_dataset_class is required when using a custom dataset")
+    LOGGER.warning("Using custom dataset class, deterministic training is not guaranteed")
+    LOGGER.info(f"Loading custom dataset {train_config.data.custom_dataset.name} from module {train_config.data.custom_dataset.module}")
     dataset_class = train_config.data.custom_dataset.name
     dataset_module = train_config.data.custom_dataset.module
     if not dataset_module:

--- a/olmo/data/custom_datasets.py
+++ b/olmo/data/custom_datasets.py
@@ -1,0 +1,32 @@
+import importlib
+from typing import Optional, Tuple
+
+from torch.utils.data import Dataset
+
+from ..config import TrainConfig
+from ..exceptions import OLMoConfigurationError
+
+__all__ = ["build_custom_dataset"]
+
+def build_custom_dataset(train_config: TrainConfig) -> Dataset:
+    if not train_config.data.custom_dataset.name:
+        raise OLMoConfigurationError("custom_dataset_class is required when using a custom dataset")
+    dataset_class = train_config.data.custom_dataset.name
+    dataset_module = train_config.data.custom_dataset.module
+    if not dataset_module:
+        dataset_module, dataset_class = extract_module_and_class(dataset_class)
+    if dataset_module is None:
+        raise OLMoConfigurationError(
+            "when using custom_dataset_class, use the full module path of the class or specify custom_dataset_module"
+        )
+    module = importlib.import_module(dataset_module)
+    dataset_class = getattr(module, dataset_class)
+    return dataset_class(**train_config.data.custom_dataset.args)  # type: ignore
+
+
+def extract_module_and_class(name: str) -> Tuple[Optional[str], str]:
+    class_module = name.split(".")
+    if len(class_module) < 2:
+        return None, class_module[0]
+    return ".".join(class_module[:-1]), class_module[-1]
+

--- a/olmo/data/iterable_dataset.py
+++ b/olmo/data/iterable_dataset.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import math
 from pathlib import Path
@@ -184,5 +185,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
         item = self.dataset[idx]
         if isinstance(item, dict):
             return dict(**item, index=idx)
+        elif dataclasses.is_dataclass(item):
+            return dict(**dataclasses.asdict(item), index=idx)
         else:
             return {"input_ids": item, "index": idx}

--- a/olmo/data/iterable_dataset.py
+++ b/olmo/data/iterable_dataset.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 import dataclasses
 import logging
 import math
@@ -183,7 +184,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
 
     def _get_dataset_item(self, idx: int) -> Dict[str, Any]:
         item = self.dataset[idx]
-        if isinstance(item, dict):
+        if isinstance(item, dict) or isinstance(item, UserDict):
             return dict(**item, index=idx)
         elif dataclasses.is_dataclass(item):
             return dict(**dataclasses.asdict(item), index=idx)

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -242,7 +242,6 @@ class Trainer:
 
     @property
     def dataset(self) -> IterableDataset:
-        assert isinstance(self.train_loader.dataset, IterableDataset)
         return self.train_loader.dataset
 
     @property
@@ -251,7 +250,10 @@ class Trainer:
 
     @property
     def batches_per_epoch(self) -> int:
-        return self.dataset.total_size // self.cfg.global_train_batch_size
+        if isinstance(self.dataset, IterableDataset):
+            return self.dataset.total_size // self.cfg.global_train_batch_size
+        else:
+            return len(self.dataset) // self.cfg.global_train_batch_size
 
     @property
     def max_epochs(self) -> int:
@@ -384,7 +386,7 @@ class Trainer:
 
         assert self.epoch is not None
         # Reshuffle dataset if needed.
-        if self.dataset.epoch != self.epoch:
+        if self.dataset.epoch != self.epoch and isinstance(self.dataset, IterableDataset):
             log.info(f"Reshuffling data loader for epoch {self.epoch}...")
             self.dataset.reshuffle(self.epoch)
 
@@ -398,8 +400,7 @@ class Trainer:
             # NOTE: on the other hand we don't add anything to 'self.global_train_tokens_seen' here because
             # that variable is meant to track the actual number of tokens trained on.
 
-        if self.global_train_examples_seen_this_epoch > 0:
-            assert isinstance(self.dataset, IterableDataset)
+        if self.global_train_examples_seen_this_epoch > 0 and isinstance(self.dataset, IterableDataset):
             log.info(f"Data loader will start at instance index {self.global_train_examples_seen_this_epoch:,d}")
             self.dataset.start_index = self.global_train_examples_seen_this_epoch
 
@@ -1183,6 +1184,9 @@ class Trainer:
 
         with torch_profiler as p:
             for epoch in range(self.epoch or 0, self.max_epochs):
+                if not isinstance(self.dataset, IterableDataset):
+                    if isinstance(self.train_loader.sampler, torch.utils.data.DistributedSampler):
+                        self.train_loader.sampler.set_epoch(self.epoch or 0)
                 for batch in self.train_loader:
                     # Bookkeeping.
                     # NOTE: To track the global batch size / number of tokens per batch we make the assumption that all
@@ -1338,7 +1342,7 @@ class Trainer:
                     self.epoch = epoch + 1
                     self.global_train_examples_seen_this_epoch = 0
                     self.dataset.start_index = 0
-                    if self.epoch < self.max_epochs:
+                    if self.epoch < self.max_epochs and isinstance(self.dataset, IterableDataset):
                         log.info(f"Reshuffling data loader for epoch {self.epoch}...")
                         self.dataset.reshuffle(self.epoch)
                     continue

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -386,7 +386,7 @@ class Trainer:
 
         assert self.epoch is not None
         # Reshuffle dataset if needed.
-        if self.dataset.epoch != self.epoch and isinstance(self.dataset, IterableDataset):
+        if isinstance(self.dataset, IterableDataset) and self.dataset.epoch != self.epoch:
             log.info(f"Reshuffling data loader for epoch {self.epoch}...")
             self.dataset.reshuffle(self.epoch)
 

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -242,6 +242,7 @@ class Trainer:
 
     @property
     def dataset(self) -> IterableDataset:
+        assert isinstance(self.train_loader.dataset, IterableDataset)
         return self.train_loader.dataset
 
     @property
@@ -398,6 +399,7 @@ class Trainer:
             # that variable is meant to track the actual number of tokens trained on.
 
         if self.global_train_examples_seen_this_epoch > 0:
+            assert isinstance(self.dataset, IterableDataset)
             log.info(f"Data loader will start at instance index {self.global_train_examples_seen_this_epoch:,d}")
             self.dataset.start_index = self.global_train_examples_seen_this_epoch
 


### PR DESCRIPTION
In order to support integration with general datasets, adding a custom dataset class option to the olmo data config. Immediate goal for this is to enable tatm datasets to work with Olmo without breaking existing functionality.

Testing Instructions:

- **environment setup**:
  - Install `pytorch` per OLMo instructions [here](https://github.com/KempnerInstitute/OLMo/blob/main/README_KempnerInstitute.md)
  - Install `tatm` v0.2.1 or greater per instructions [here](https://github.com/KempnerInstitute/OLMo/blob/main/README_KempnerInstitute.md)
  - Install `OLMo` per standard repo instructions
  - On the Kempner cluster, follow instructions [here](https://handbook.eng.kempnerinstitute.harvard.edu/storage_and_data_transfer/testbed_and_tatm.html#using-tatm-on-the-kempner-hpc-cluster) to be able to use the Kempner Metadata backend. Specifically the setting of the `TATM_BASE_DIR` environment variable.
- **Testing the change**:
  - Use the included example config at `configs/kempner_institute/7b_Olmo_tatm.yaml` with the OLMO run instructions to confirm that training proceded as expected, check logs for evidence of the use of the `tatm` dataset. Confirm that loss goes down
  - Confirm that other OLMo configurations work without issue
  - Confirm that restarting from a checkpoint appears to function